### PR TITLE
Fix the repo link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/mapbox/rehype-prism.git"
+    "url": "git+https://github.com/j0lv3r4/mdx-prism.git"
   },
   "keywords": [
     "rehype",


### PR DESCRIPTION
The repo URL still uses the original's, this makes dependabot confused (https://github.com/JohnTitor/2k36.org/pull/33#issue-699022941), I presume.